### PR TITLE
feat: Oauth 기능 구현

### DIFF
--- a/src/main/java/org/example/food/auth/dto/CustomOAuth2User.java
+++ b/src/main/java/org/example/food/auth/dto/CustomOAuth2User.java
@@ -1,0 +1,52 @@
+package org.example.food.auth.dto;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final UserDTO userDTO;
+
+    public CustomOAuth2User(UserDTO userDTO) {
+
+        this.userDTO = userDTO;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+
+                return userDTO.getRole();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+
+        return userDTO.getName();
+    }
+
+    public String getUsername() {
+
+        return userDTO.getUsername();
+    }
+}

--- a/src/main/java/org/example/food/auth/dto/NaverResponse.java
+++ b/src/main/java/org/example/food/auth/dto/NaverResponse.java
@@ -1,0 +1,37 @@
+package org.example.food.auth.dto;
+
+import java.util.Map;
+
+public class NaverResponse implements OAuth2Response {
+
+    private final Map<String, Object> attribute;
+
+    public NaverResponse(Map<String, Object> attribute) {
+
+        this.attribute = (Map<String, Object>) attribute.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+
+        return attribute.get("name").toString();
+    }
+}

--- a/src/main/java/org/example/food/auth/dto/OAuth2Response.java
+++ b/src/main/java/org/example/food/auth/dto/OAuth2Response.java
@@ -1,0 +1,12 @@
+package org.example.food.auth.dto;
+
+public interface OAuth2Response {
+
+    String getProvider();
+    //제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+    //이메일
+    String getEmail();
+    //사용자 실명 (설정한 이름)
+    String getName();
+}

--- a/src/main/java/org/example/food/auth/dto/UserDTO.java
+++ b/src/main/java/org/example/food/auth/dto/UserDTO.java
@@ -1,0 +1,13 @@
+package org.example.food.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserDTO {
+
+    private String role;
+    private String name;
+    private String username;
+}

--- a/src/main/java/org/example/food/auth/jwt/JWTFilter.java
+++ b/src/main/java/org/example/food/auth/jwt/JWTFilter.java
@@ -1,0 +1,87 @@
+package org.example.food.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.food.auth.dto.CustomOAuth2User;
+import org.example.food.auth.dto.UserDTO;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    public JWTFilter(JWTUtil jwtUtil) {
+
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String authorization = null;
+        Cookie[] cookies = request.getCookies();
+
+        if(cookies == null){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("Authorization")) {
+
+                authorization = cookie.getValue();
+            }
+        }
+
+        //Authorization 헤더 검증
+        if (authorization == null) {
+
+            System.out.println("token null");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        }
+
+        //토큰
+        String token = authorization;
+
+        if (jwtUtil.isExpired(token)) {
+
+            System.out.println("token expired");
+            filterChain.doFilter(request, response);
+
+            //조건이 해당되면 메소드 종료 (필수)
+            return;
+        }
+
+        //토큰에서 username과 role 획득
+        String username = jwtUtil.getUsername(token);
+        String role = jwtUtil.getRole(token);
+
+        //userDTO를 생성하여 값 set
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUsername(username);
+        userDTO.setRole(role);
+
+        //UserDetails에 회원 정보 객체 담기
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDTO);
+
+        //스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
+        //세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/example/food/auth/jwt/JWTUtil.java
+++ b/src/main/java/org/example/food/auth/jwt/JWTUtil.java
@@ -1,0 +1,47 @@
+package org.example.food.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String username, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/org/example/food/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/org/example/food/auth/oauth2/CustomSuccessHandler.java
@@ -1,0 +1,57 @@
+package org.example.food.auth.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.food.auth.dto.CustomOAuth2User;
+import org.example.food.auth.jwt.JWTUtil;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+@Component
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JWTUtil jwtUtil;
+
+    public CustomSuccessHandler(JWTUtil jwtUtil) {
+
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        //OAuth2User
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        String username = customUserDetails.getUsername();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        String token = jwtUtil.createJwt(username, role, 60*60*60*60L);
+
+        response.addCookie(createCookie("Authorization", token));
+        response.sendRedirect("http://localhost:3000/");
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*60*60);
+        //cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/org/example/food/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/example/food/auth/service/CustomOAuth2UserService.java
@@ -1,0 +1,75 @@
+package org.example.food.auth.service;
+
+import org.example.food.auth.dto.CustomOAuth2User;
+import org.example.food.auth.dto.NaverResponse;
+import org.example.food.auth.dto.OAuth2Response;
+import org.example.food.auth.dto.UserDTO;
+import org.example.food.user.entity.User;
+import org.example.food.user.repository.UserRepository;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    public CustomOAuth2UserService(UserRepository userRepository) {
+
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println(oAuth2User);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+        if (registrationId.equals("naver")) {
+
+            oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+        } else {
+
+            return null;
+        }
+        String username = oAuth2Response.getProvider()+" "+oAuth2Response.getProviderId();
+        User existData = userRepository.findByUsername(username);
+
+        if (existData == null) {
+
+            User userEntity = new User();
+            userEntity.setUsername(username);
+            userEntity.setEmail(oAuth2Response.getEmail());
+            userEntity.setName(oAuth2Response.getName());
+            userEntity.setRole("ROLE_USER");
+
+            userRepository.save(userEntity);
+
+            UserDTO userDTO = new UserDTO();
+            userDTO.setUsername(username);
+            userDTO.setName(oAuth2Response.getName());
+            userDTO.setRole("ROLE_USER");
+
+            return new CustomOAuth2User(userDTO);
+        }
+        else {
+
+            existData.setEmail(oAuth2Response.getEmail());
+            existData.setName(oAuth2Response.getName());
+
+            userRepository.save(existData);
+
+            UserDTO userDTO = new UserDTO();
+            userDTO.setUsername(existData.getUsername());
+            userDTO.setName(oAuth2Response.getName());
+            userDTO.setRole(existData.getRole());
+
+            return new CustomOAuth2User(userDTO);
+        }
+    }
+}


### PR DESCRIPTION
# 📌 OAuth2 로그인 기능 구현 PR  

## 🔥 작업 내용  
- **OAuth2 로그인 성공 시 JWT 발급 및 쿠키 저장**  
  - `CustomSuccessHandler`에서 로그인 성공 시 JWT 생성 후 `Authorization` 쿠키로 저장  
  - `JWTUtil`을 활용하여 사용자 이름과 역할을 포함한 토큰 생성  

- **OAuth2 사용자 정보 처리 및 DB 저장/업데이트**  
  - `CustomOAuth2UserService`에서 OAuth2 제공자(`naver`)별 응답 데이터 매핑  
  - 신규 사용자일 경우 DB에 저장, 기존 사용자일 경우 정보 업데이트  

## ✅ 주요 변경 사항  
- `CustomSuccessHandler` 추가 (JWT 생성 및 쿠키 저장 로직 포함)  
- `CustomOAuth2UserService`에서 사용자 정보 조회 및 저장 로직 구현  
- OAuth2 사용자 응답을 `CustomOAuth2User` 객체로 변환하여 반환  

## 🎯 기대 효과  
- OAuth2 로그인 사용자에 대한 JWT 기반 인증 처리 가능  
- 로그인 후 자동으로 프론트엔드(`http://localhost:3000/`)로 이동  
- 사용자 정보가 DB에 저장되며, 기존 사용자는 정보가 최신화됨  

## 📌 참고 사항  
- 현재 `naver` 로그인만 지원 (추후 확장 가능)  
- 쿠키 설정에서 `setSecure(true)`는 개발 환경에서는 주석 처리  
- 토큰 만료 시간(`60*60*60*60L`)은 추후 조정 가능  
+ appilcation.properties에 registration, provider 삽입