### PR TITLE
[feat]  게시글 좋아요 기능

### DIFF
--- a/src/main/java/org/example/food/board/repository/BoardRepository.java
+++ b/src/main/java/org/example/food/board/repository/BoardRepository.java
@@ -13,5 +13,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     List<Board> findAllByCategoryIn(List<Category> categories);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE board SET like_count = like_count + 1 WHERE board_id = :boardId", nativeQuery = true)
+    void increaseLikeCount(Long boardId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE board SET like_count = like_count - 1 WHERE board_id = :boardId", nativeQuery = true)
+    void decreaseLikeCount(Long boardId);
+
     Slice<Board> findSliceBy(final Pageable pageable);
 }

--- a/src/main/java/org/example/food/like/controller/LikeController.java
+++ b/src/main/java/org/example/food/like/controller/LikeController.java
@@ -1,0 +1,32 @@
+package org.example.food.like.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.food.like.dto.LikeFlipResponse;
+import org.example.food.like.service.LikeService;
+import org.example.food.user.entity.User;
+import org.example.food.user.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/boards")
+public class LikeController {
+
+    private final LikeService likeService;
+    private final UserRepository userRepository;
+    @PutMapping("/{boardId}/like")
+    public ResponseEntity<LikeFlipResponse> likeBoard(
+            @PathVariable Long boardId) {
+        User user = userRepository.findById(1L).orElseThrow();
+//        LoginUser User user
+        LikeFlipResponse likeFlipResponse = likeService.flipboardLike(boardId, user);
+        return new ResponseEntity<>(likeFlipResponse, HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/example/food/like/dto/LikeFlipResponse.java
+++ b/src/main/java/org/example/food/like/dto/LikeFlipResponse.java
@@ -1,0 +1,18 @@
+package org.example.food.like.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LikeFlipResponse {
+
+    private int likeCount;
+    private boolean like;
+
+    public LikeFlipResponse() {
+    }
+
+    public LikeFlipResponse(int likeCount, boolean like) {
+        this.likeCount = likeCount;
+        this.like = like;
+    }
+}

--- a/src/main/java/org/example/food/like/entity/Like.java
+++ b/src/main/java/org/example/food/like/entity/Like.java
@@ -1,0 +1,42 @@
+package org.example.food.like.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.food.user.entity.User;
+import org.example.food.board.entity.Board;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Table(name = "likes")
+public class Like {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @Builder
+    private Like(User user, Board board) {
+        this.user = user;
+        this.board = board;
+    }
+
+    public boolean isLikeOf(Long userId) {
+        return user.hasId(userId);
+    }
+
+    public void delete() {
+        this.board = null;
+    }
+}

--- a/src/main/java/org/example/food/like/repository/LikeRepository.java
+++ b/src/main/java/org/example/food/like/repository/LikeRepository.java
@@ -1,0 +1,18 @@
+package org.example.food.like.repository;
+
+import org.example.food.like.entity.Like;
+import org.example.food.user.entity.User;
+import org.example.food.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import org.springframework.data.repository.query.Param;
+
+public interface LikeRepository extends JpaRepository<Like, Integer> {
+
+    boolean existsByBoardAndUserId(Board board, Long UserId);
+
+    Optional<Like> findByBoardAndUserId(Board board, Long UserId);
+
+    boolean existsByUserIdAndBoardId(Long userId, Long reviewId);
+}

--- a/src/main/java/org/example/food/like/service/LikeService.java
+++ b/src/main/java/org/example/food/like/service/LikeService.java
@@ -1,0 +1,61 @@
+package org.example.food.like.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.example.food.board.entity.Board;
+import org.example.food.board.repository.BoardRepository;
+import org.example.food.like.dto.LikeFlipResponse;
+import org.example.food.like.entity.Like;
+import org.example.food.like.repository.LikeRepository;
+import org.example.food.user.entity.User;
+import org.example.food.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public LikeFlipResponse flipboardLike(Long boardId, User user) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(RuntimeException::new);
+
+        int likeCount = flipboardLike(user.getId(), board);
+
+        boolean liked = likeRepository.existsByBoardAndUserId(board, user.getId());
+
+        return new LikeFlipResponse(likeCount, liked);
+    }
+
+    private int flipboardLike(Long UserId, Board board) {
+        final Optional<Like> like = likeRepository.findByBoardAndUserId(board, UserId);
+
+        if (like.isPresent()) {
+            board.deleteLike(like.get());
+            boardRepository.decreaseLikeCount(board.getId());
+            return board.getLikeCount() - 1;
+        }
+
+        // 좋아요를 추가하는 경우
+        addNewboardLike(UserId, board);
+        boardRepository.increaseLikeCount(board.getId());
+        return board.getLikeCount() + 1;
+    }
+
+    private void addNewboardLike(Long userId, Board board) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(RuntimeException::new);
+
+        Like boardLike = Like.builder()
+                .user(user)
+                .board(board)
+                .build();
+        likeRepository.save(boardLike);
+    }
+
+}


### PR DESCRIPTION
# 📌 게시글 엔티티 수정: 동시성 문제 해결 및 반정규화로 인한 데드락 문제 해결  

## 🔥 작업 내용  
- **게시글 좋아요 기능 구현**  
  - `LikeService`를 통해 사용자가 게시글에 좋아요를 추가/취소할 수 있도록 구현  
  - `LikeRepository`를 활용하여 좋아요 여부 확인 및 추가/삭제 처리  
  - `BoardRepository`에서 `like_count` 값을 증가/감소시키는 쿼리 작성  

- **좋아요 요청 API 추가 (`LikeController`)**  
  - `PUT /api/boards/{boardId}/like` 엔드포인트 생성  

- **좋아요 데이터 모델링 (`Like` 엔티티 추가)**  
  - `User`와 `Board`를 `ManyToOne` 관계로 연결하여 `Like` 엔티티 생성  
  - 특정 사용자가 특정 게시글을 좋아요했는지 확인하는 메서드 추가  

- **좋아요 DTO 생성 (`LikeFlipResponse`)**  
  - 좋아요 개수와 사용자의 좋아요 여부를 반환하는 `LikeFlipResponse` 생성  

보드 엔티티에 likes 매핑해주고 likeCount로 추가 쿼리 없이 좋아요 개수 반환
```
private int likeCount = 0;
@OneToMany(mappedBy = "board", cascade = CascadeType.PERSIST, orphanRemoval = true)
    private List<Like> likes = new ArrayList<>();
```

- **반정규화로 인한 데드락 문제 해결**  
  - `like_count` 필드를 DB에서 직접 수정하는 방식 대신, `Like` 엔티티를 통해 관리  
  - `deleteLike()` 및 `addNewboardLike()` 로직에서 `like_count` 값 직접 변경  

## ✅ 주요 변경 사항  
- `like_count` 값을 직접 업데이트하는 로직 개선  
- `deleteLike()` 및 `addComment()` 등 관계 엔티티 조작 시 동시성 고려  
- `BoardRepository`의 `increaseLikeCount` 및 `decreaseLikeCount` 트랜잭션 처리 강화  

## 🎯 기대 효과  
- 다중 사용자의 동시 요청에서도 `like_count` 값 정확하게 반영  
- 반정규화로 인한 `board` 테이블의 데드락 발생 가능성 최소화  
- `@Transactional` 및 `@Lock` 설정을 활용한 안전한 업데이트 처리  

## 📌 참고 사항  
- 현재 로그인된 사용자를 가져오는 로직(`userRepository.findById(1L)`)은 추후 OAuth2 인증 적용 시 수정 필요  
- `like_count` 값은 `Board` 엔티티에서 관리되며, `increaseLikeCount` 및 `decreaseLikeCount` 쿼리를 통해 업데이트됨  
