### PR TITLE
Fetch Join을 통한 N+1 문제 해결

### DIFF
--- a/src/main/java/org/example/food/board/controller/BoardController.java
+++ b/src/main/java/org/example/food/board/controller/BoardController.java
@@ -38,10 +38,10 @@ public class BoardController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Void> getBoard(@PathVariable Long id, @LoginUser User user) {
+    public ResponseEntity<BoardDetailResponse> getBoard(@PathVariable Long id, @LoginUser User user) {
 
         BoardDetailResponse boardResponse = boardService.getBoard(id, user);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(boardResponse);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/org/example/food/board/repository/BoardRepository.java
+++ b/src/main/java/org/example/food/board/repository/BoardRepository.java
@@ -4,11 +4,13 @@ import org.example.food.board.entity.Category;
 import org.example.food.board.entity.Board;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
@@ -24,5 +26,12 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query(value = "UPDATE board SET like_count = like_count - 1 WHERE board_id = :boardId", nativeQuery = true)
     void decreaseLikeCount(Long boardId);
 
-    Slice<Board> findSliceBy(final Pageable pageable);
+    @Query("SELECT b FROM Board b")
+    @EntityGraph(attributePaths = {"comments", "user"})
+    Slice<Board> findSliceBy(Pageable pageable);
+
+    @Query("SELECT b FROM Board b WHERE b.id = :boardId")
+    @EntityGraph(attributePaths = {"comments", "user"})
+    Board findBoardWithComments(@Param("boardId") Long boardId);
+
 }

--- a/src/main/java/org/example/food/board/service/BoardServiceImpl.java
+++ b/src/main/java/org/example/food/board/service/BoardServiceImpl.java
@@ -42,7 +42,7 @@ public class BoardServiceImpl implements BoardService {
         if (!boardRepository.existsById(id)) {
             throw new BoardException(BoardExceptionType.NOT_FOUND_board);
         }
-        Board board = boardRepository.findById(id).get();
+        Board board = boardRepository.findBoardWithComments(id);
         boolean likeState = likeRepository.existsByUserIdAndBoardId(user.getId(), board.getId());
         return BoardDetailResponse.of(board, likeState);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ spring.datasource.username=root
 spring.datasource.password=wkddudwo1!
 
 #sql
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.defer-datasource-initialization=true


### PR DESCRIPTION
### 변경 사항

- **`Fetch Join` 적용**: `Board`와 연관된 `User` 및 `Comment`를 **한 번의 쿼리로 로딩**하여 N+1 문제를 해결하고 성능을 최적화했습니다.
  
### 주요 변경 내용

- `Board` 조회 시 연관된 `User`와 `Comment`를 FetchJoin으로 함께 가져오도록 쿼리 수정.
  
#### 코드:
```java
@Query("SELECT b FROM Board b WHERE b.id = :boardId")
@EntityGraph(attributePaths = {"comments", "user"})
Board findBoardWithComments(@Param("boardId") Long boardId);
```
40 -> 1개의 쿼리 변경
### **주의사항**
- **카르테시안 곱**: 너무 많은 `JOIN` 사용 시 중복 데이터가 반환될 수 있어 주의.
- **불필요한 데이터 로딩**: 필요한 데이터만 조회하도록 최적화 필요.